### PR TITLE
Changed coolant port name to match what driver is expecting.

### DIFF
--- a/picobob_map.h
+++ b/picobob_map.h
@@ -79,7 +79,7 @@
 #define RESET_PIN             3
 
 //Stepper enable is replaced with coolant control
-#define COOLANT_FLOOD_PORT    GPIO_OUTPUT
+#define COOLANT_PORT    GPIO_OUTPUT
 #define COOLANT_FLOOD_PIN     16
 
 // Define probe switch input pin.


### PR DESCRIPTION
There was an issue with the naming of the coolant port in the PicoBOB map file vs what the driver was expecting.