### PR TITLE
Fix problem where in PIO_1 mode, state machines were not initialized

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -1791,16 +1791,15 @@ static bool driver_setup (settings_t *settings)
         z_step_pio = pio1;
     step_pulse_program_init(z_step_pio, z_step_sm, pio_offset, Z_STEP_PIN, 1);
 
-#if N_ABC_MOTORS > 1
+#if N_ABC_MOTORS > 0
 
 #if WIFI_ENABLE && N_ABC_MOTORS > 2
 #error "Max number of motors with WIFI_ENABLE is 5"
 #endif
 
-    if(++step_sm > 3) {
-        step_sm = 0;
-        pio_offset = pio_add_program(pio0, &step_pulse_program);
-    }
+    // Zero the state machine # since we are now using pio0 state machines.
+    step_sm = 0;
+    pio_offset = pio_add_program(pio0, &step_pulse_program);
 
 #ifdef X2_STEP_PIN
     x2_step_sm = step_sm++;

--- a/driver.c
+++ b/driver.c
@@ -1797,9 +1797,10 @@ static bool driver_setup (settings_t *settings)
 #error "Max number of motors with WIFI_ENABLE is 5"
 #endif
 
-    // Zero the state machine # since we are now using pio0 state machines.
-    step_sm = 0;
-    pio_offset = pio_add_program(pio0, &step_pulse_program);
+    if(++step_sm > 3) {
+        step_sm = 0;
+        pio_offset = pio_add_program(pio0, &step_pulse_program);
+    }
 
 #ifdef X2_STEP_PIN
     x2_step_sm = step_sm++;


### PR DESCRIPTION
- N_ABC_MOTORS > 0 is proper condition. I was testing with Y_GANGED which exhibited the bug. With > 1 condition, y2_sm was unitialized.
- I removed the logic that checked if the sm was >= 3. If that was ever not true, it wouldn't work properly, because everything using the sm's later is hardcoded to the pio0 for the non primary axes.