### PR TITLE
GeckoDrive G540 pin mapping for PicoBOB

### DIFF
--- a/driver.h
+++ b/driver.h
@@ -116,6 +116,8 @@
   #include "pico_cnc_map.h"
 #elif defined(BOARD_PICOBOB)
   #include "picobob_map.h"
+#elif defined(BOARD_PICOBOB_G540)
+  #include "picobob_g540_map.h"  
 #elif defined(BOARD_BTT_SKR_PICO_10)
   #include "btt_skr_pico_10_map.h"
 #elif defined BOARD_CITOH_CX6000

--- a/driver.json
+++ b/driver.json
@@ -46,6 +46,18 @@
       }
     },
     {
+      "name": "PicoBOB_G540",
+      "symbol": "BOARD_PICOBOB_G540",
+      "URL": "https://github.com/Expatria-Technologies/PicoBOB",
+      "caps": {
+        "axes": 4,
+        "digital_in": 0,
+        "digital_out": 0,
+        "safety_door": 0,
+        "sdcard": 0
+      }
+    },    
+    {
       "name": "BTT SKR Pico 1.0",
       "symbol": "BOARD_BTT_SKR_PICO_10",
       "URL": "https://biqu.equipment/products/btt-skr-pico-v1-0",

--- a/my_machine.h
+++ b/my_machine.h
@@ -23,6 +23,7 @@
 // If none is enabled pin mappings from generic_map.h will be used.
 #define BOARD_PICO_CNC
 //#define BOARD_PICOBOB
+//#define BOARD_PICOBOB_G540
 //#define BOARD_BTT_SKR_PICO_10 // incomplete and untested!
 //#define BOARD_CNC_BOOSTERPACK
 //#define BOARD_CITOH_CX6000    // C.ITOH CX-6000 HPGL plotter

--- a/picobob_g540_map.h
+++ b/picobob_g540_map.h
@@ -46,7 +46,7 @@
 #define M3_AVAILABLE
 #define M3_STEP_PIN           3 //not the Pico pin.
 #define M3_DIRECTION_PIN      12
-#define M3_LIMIT_PIN          1
+#define M3_LIMIT_PIN          2
 #endif
 
 //Define stepper driver enable/disable output pin.  This is not used on PicoBOB.
@@ -60,9 +60,7 @@
 // Define spindle enable and spindle direction output pins.  No direction signal on the Mach3 BOB.
 //Spindle relay control is shared with B direction port, only one can be enabled at a time!
 #define SPINDLE_PORT          GPIO_OUTPUT
-#ifndef M4_DIRECTION_PIN
 #define SPINDLE_ENABLE_PIN    14
-#endif
 
 // Define spindle PWM output pin.
 #define SPINDLE_PWM_PORT      GPIO_OUTPUT

--- a/picobob_g540_map.h
+++ b/picobob_g540_map.h
@@ -1,0 +1,81 @@
+/*
+  picobob_map.h - driver code for RP2040 ARM processors
+
+  Part of grblHAL
+
+  Copyright (c) 2021-2022 Terje Io
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if TRINAMIC_ENABLE
+#error Trinamic plugin not supported!
+#endif
+
+#if N_ABC_MOTORS > 2
+#error "Axis configuration is not supported!"
+#endif
+
+#define BOARD_NAME "PicoBOB_G540"
+#define BOARD_URL "https://github.com/Expatria-Technologies/PicoBOB"
+
+// Define step pulse output pins.
+#define STEP_PORT             GPIO_PIO  // N_AXIS pin PIO SM
+#define STEP_PINS_BASE        17        // N_AXIS number of consecutive pins are used by PIO
+
+// Define step direction output pins.
+#define DIRECTION_PORT        GPIO_OUTPUT
+#define DIRECTION_OUTMODE     GPIO_MAP
+#define X_DIRECTION_PIN       9
+#define Y_DIRECTION_PIN       10
+#define Z_DIRECTION_PIN       11
+
+// Define ganged axis or A axis step pulse and step direction output pins.
+#if N_ABC_MOTORS > 0
+#define M3_AVAILABLE
+#define M3_STEP_PIN           3 //not the Pico pin.
+#define M3_DIRECTION_PIN      12
+#define M3_LIMIT_PIN          1
+#endif
+
+//Define stepper driver enable/disable output pin.  This is not used on PicoBOB.
+
+// Define homing/hard limit switch input pins.  Currently configured so that X, Y and Z limit pins are shared.
+#define LIMIT_PORT            GPIO_INPUT
+#define X_LIMIT_PIN           3
+#define Y_LIMIT_PIN           3
+#define Z_LIMIT_PIN           3
+
+// Define spindle enable and spindle direction output pins.  No direction signal on the Mach3 BOB.
+//Spindle relay control is shared with B direction port, only one can be enabled at a time!
+#define SPINDLE_PORT          GPIO_OUTPUT
+#ifndef M4_DIRECTION_PIN
+#define SPINDLE_ENABLE_PIN    14
+#endif
+
+// Define spindle PWM output pin.
+#define SPINDLE_PWM_PORT      GPIO_OUTPUT
+#define SPINDLE_PWM_PIN       16
+
+// Define user-control controls (cycle start, reset, feed hold) input pins.
+#define RESET_PIN             5
+#define FEED_HOLD_PIN         1
+
+//Stepper enable is replaced with coolant control
+#define COOLANT_PORT    GPIO_OUTPUT
+#define COOLANT_FLOOD_PIN     13
+
+// Define probe switch input pin.
+#define PROBE_PIN             4
+#define PROBE_PORT            GPIO_INPUT

--- a/picobob_map.h
+++ b/picobob_map.h
@@ -38,7 +38,7 @@
 #define DIRECTION_PORT        GPIO_OUTPUT
 #define DIRECTION_OUTMODE     GPIO_MAP
 #define X_DIRECTION_PIN       9
-#define Y_DIRECTION_PIN       0
+#define Y_DIRECTION_PIN       10
 #define Z_DIRECTION_PIN       11
 
 // Define ganged axis or A axis step pulse and step direction output pins.


### PR DESCRIPTION
Updated the PicoBOB map file to support the pinout and functions of the G540 from Gecko.