### PR TITLE
Fix compile by adding hardware_dma pic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ target_link_libraries(grblHAL PRIVATE
  spindle
  tinyusb_device_unmarked
  pico_stdlib
+ hardware_dma
  hardware_uart
  hardware_pio
  hardware_i2c


### PR DESCRIPTION
Include path was not being added in API, resulting in #include "hardware/dma.h" not working. Fixed by adding target link library.