### PR TITLE
Fix to allow trinamic plugin to detect ganged axis drivers

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -1962,6 +1962,7 @@ bool driver_init (void)
     hal.stepper.enable = stepperEnable;
     hal.stepper.cycles_per_tick = stepperCyclesPerTick;
     hal.stepper.pulse_start = stepperPulseStart;
+    hal.stepper.motor_iterator = motor_iterator;
 #ifdef GANGING_ENABLED
     hal.stepper.get_ganged = getGangedAxes;
 #endif


### PR DESCRIPTION
Trinamic plugin detects amount of drivers based on `motor_iterator` or based on number of axis if no `motor_iterator` provided.
(https://github.com/grblHAL/Plugins_motor/blob/master/trinamic.c#L1812). In case of ganged axis `M122` and other commands operate only on one of two motors for ganged axis if no `hal.stepper.motor_iterator` privided. This change makes `motor_iterator` available to Trinamic plugin via `hal.stepper.motor_iterator` and allows to detect all drivers.