### PR TITLE
Add support for picoHAL CNC controller

### DIFF
--- a/boards/picohal_map.h
+++ b/boards/picohal_map.h
@@ -1,0 +1,130 @@
+/*
+  picoHAL_map.h - Board mapping for PicoHAL (modified for custom use)
+
+  Part of grblHAL
+
+  Copyright (c) 2021-2023 Andrew Marles
+  Copyright (c) 2024 Mitchell Grams
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if TRINAMIC_ENABLE
+#error Trinamic plugin not supported!
+#endif
+
+#if N_ABC_MOTORS > 1
+#error "Axis configuration is not supported!"
+#endif
+
+#define BOARD_NAME "PicoHAL"
+#define BOARD_URL "https://github.com/Expatria-Technologies/PicoHAL"
+
+// Define step pulse output pins.
+#define STEP_PORT             GPIO_PIO  // N_AXIS pin PIO SM
+#define STEP_PINS_BASE        20        // N_AXIS number of consecutive pins are used by PIO
+
+// Define step direction output pins.
+#define DIRECTION_PORT        GPIO_OUTPUT
+#define DIRECTION_OUTMODE     GPIO_MAP
+#define X_DIRECTION_PIN       16
+#define Y_DIRECTION_PIN       17
+#define Z_DIRECTION_PIN       18
+
+// Define stepper driver enable/disable output pin.
+#define ENABLE_PORT           GPIO_OUTPUT
+#define STEPPERS_ENABLE_PIN   24
+
+// Define ganged axis or A axis step pulse and step direction output pins.
+#if N_ABC_MOTORS > 0
+#define M3_AVAILABLE
+#define M3_DIRECTION_PIN      19
+#define M3_LIMIT_PIN          5  //shared with Z
+#endif
+
+// Define homing/hard limit switch input pins.  Currently configured so that X and Z limit pins are shared.
+#define LIMIT_PORT            GPIO_INPUT
+#define X_LIMIT_PIN           15
+#define Y_LIMIT_PIN           10
+#define Z_LIMIT_PIN           5
+
+// Aux Outputs
+#define AUXOUTPUT0_PORT         GPIO_OUTPUT // MODBUS DIRECTION
+#define AUXOUTPUT0_PIN          27
+#define AUXOUTPUT1_PORT         GPIO_OUTPUT // Spindle enable
+#define AUXOUTPUT1_PIN          7
+#define AUXOUTPUT2_PORT         GPIO_OUTPUT // Spindle PWM (2 pin PWM port)
+#define AUXOUTPUT2_PIN          25
+#define AUXOUTPUT3_PORT         GPIO_OUTPUT // Spindle Direction (3 pin 'Neopixel" driver)
+#define AUXOUTPUT3_PIN          26
+#define AUXOUTPUT4_PORT         GPIO_OUTPUT // Stepper enable
+#define AUXOUTPUT4_PIN          24
+
+#if DRIVER_SPINDLE_ENABLE
+#define SPINDLE_PORT            GPIO_OUTPUT
+#endif
+#if DRIVER_SPINDLE_ENABLE & SPINDLE_ENA
+#define SPINDLE_ENABLE_PIN      AUXOUTPUT1_PIN
+#endif
+#if DRIVER_SPINDLE_ENABLE & SPINDLE_PWM
+#define SPINDLE_PWM_PIN         AUXOUTPUT2_PIN
+#endif
+#if DRIVER_SPINDLE_ENABLE & SPINDLE_DIR
+#define SPINDLE_DIRECTION_PIN   AUXOUTPUT3_PIN
+#endif
+
+// Aux Inputs
+#define AUXINPUT0_PIN           6  // CNC shield HOLD pin
+#define AUXINPUT1_PIN           11 // CNC shield RUN pin
+#define AUXINPUT2_PIN           28 // CNC shield A4 (ADC capable, 3.3V max)
+#define AUXINPUT3_PIN           29 // CNC shield A5 (ADC capable, 3.3V max)
+
+#if PROBE_ENABLE
+#define PROBE_PIN               AUXINPUT3_PIN
+#endif
+
+// Modbus 
+#define MODBUS_DIR_AUX  0
+
+#define SERIAL1_PORT 1
+
+#if MODBUS_ENABLE
+#define MODBUS_SERIAL_PORT          1
+#endif
+
+// UART 0
+#define UART_TX_PIN 12
+#define UART_RX_PIN 13
+
+// UART 1 (Modbus)
+#define UART_1_TX_PIN 8
+#define UART_1_RX_PIN 9
+
+#define MODBUS_DIR_AUX  0
+#define SERIAL1_PORT 1
+
+#if MODBUS_ENABLE
+#define MODBUS_SERIAL_PORT          1
+#endif
+
+// Ethernet
+#if ETHERNET_ENABLE
+#define SPI_PORT            0
+#define SPI_SCK_PIN         2
+#define SPI_MOSI_PIN        3
+#define SPI_MISO_PIN        0
+#define SPI_CS_PIN          1
+#define SPI_IRQ_PIN         4
+#define SPI_RST_PORT        GPIO_OUTPUT
+#endif

--- a/driver.c
+++ b/driver.c
@@ -84,6 +84,7 @@
 #if LITTLEFS_ENABLE
 #include "littlefs_hal.h"
 #include "sdcard/fs_littlefs.h"
+#include "sdcard/macros.h"
 #endif
 
 #if USB_SERIAL_CDC
@@ -2562,6 +2563,8 @@ static bool driver_setup (settings_t *settings)
 
 #if SDCARD_ENABLE
     sdcard_init();
+#elif LITTLEFS_ENABLE
+    fs_macros_init();
 #endif
 
 #if MPG_ENABLE == 1

--- a/driver.h
+++ b/driver.h
@@ -147,7 +147,9 @@
 #elif defined(BOARD_PICOBOB_DLX)
   #include "boards/picobob_dlx_map.h" 
 #elif defined(BOARD_PICOBOB_DLX_G540)
-  #include "boards/picobob_dlx_g540_map.h"      
+  #include "boards/picobob_dlx_g540_map.h"
+#elif defined(BOARD_PICOHAL)
+  #include "boards/picohal_map.h"        
 #elif defined(BOARD_BTT_SKR_PICO_10)
   #include "boards/btt_skr_pico_10_map.h"
 #elif defined BOARD_CITOH_CX6000

--- a/my_machine.h
+++ b/my_machine.h
@@ -27,6 +27,7 @@
 //#define BOARD_PICOBOB_G540
 //#define BOARD_PICOBOB_DLX
 //#define BOARD_PICOBOB_DLX_G540
+//#define BOARD_PICOHAL
 //#define BOARD_BTT_SKR_PICO_10 // incomplete and untested!
 //#define BOARD_CNC_BOOSTERPACK
 //#define BOARD_CITOH_CX6000    // C.ITOH CX-6000 HPGL plotter

--- a/serial.c
+++ b/serial.c
@@ -34,8 +34,12 @@
 #define RX_BUFFER_HWM 800
 #define RX_BUFFER_LWM 300
 
+#ifndef UART_TX_PIN
 #define UART_TX_PIN 0
+#endif
+#ifndef UART_RX_PIN
 #define UART_RX_PIN 1
+#endif
 
 #ifndef UART_PORT
 #define UART_PORT uart0


### PR DESCRIPTION
Add support for picoHAL CNC controller (https://github.com/Expatria-Technologies/PicoHAL_HW):

- Add board map based on draft version published by Expatria (https://github.com/Expatria-Technologies/RP2040/tree/picohal_map)
- Update to serial.c to permit nonstandard UART pins
- Update driver.c to support running macros from littleFS without SD card enabled