### PR TITLE
Fix typo in AuxInput4 (Reset) pin definition

### DIFF
--- a/boards/picobob_dlx_map.h
+++ b/boards/picobob_dlx_map.h
@@ -116,12 +116,12 @@
 #define AUXINPUT2_PIN         27 // I2C strobe
 #define AUXINPUT3_PIN         4  // Probe
 #ifndef I2C_STROBE_ENABLE
-  #define AUXINPUT1_PIN       3
-  #define AUXINPUT4_PIN       15 // Reset
+  #define AUXINPUT1_PIN       15
+  #define AUXINPUT4_PIN       3 // Reset
 #else
   //reset pin is swapped to keypad when present, frees up additional input.
-  #define AUXINPUT1_PIN       15
-  #define AUXINPUT4_PIN       3  // Reset
+  #define AUXINPUT1_PIN       3
+  #define AUXINPUT4_PIN       15  // Reset
 #endif
 
 #if CONTROL_ENABLE & CONTROL_HALT


### PR DESCRIPTION
Fix typo in board map for PicoBOB DLX