### PR TITLE
Assign SERIAL1 to 'Laser' connector.

### DIFF
--- a/boards/btt_skr_pico_10_map.h
+++ b/boards/btt_skr_pico_10_map.h
@@ -145,3 +145,10 @@
 #if MODBUS_ENABLE
 #define MODBUS_RTU_STREAM           0
 #endif
+
+// SERIAL1 is on TX 8 and RX 9 by default.
+// SKR Pico has a connector (labeled "Laser" in the Bigtreetech documentation)
+// which has two IO pins, GND, and +5V, making it ideal for MPG etc.
+#define UART1_TX_PIN 0
+#define UART1_RX_PIN 1
+


### PR DESCRIPTION
The default assignment of IO8/9 is not useful for the SKR Pico, since that is used for the Trinamic drivers.

This PR moves SERIAL1 to IO0/1 instead - the Trinamic commands still seem to work fine, even though I don't quite understand why.