### PR TITLE
Extend Content-Type mapping for wasm/svg/...

### DIFF
--- a/lwipopts.h
+++ b/lwipopts.h
@@ -95,3 +95,22 @@
 #define PPP_DEBUG                   LWIP_DBG_OFF
 #define SLIP_DEBUG                  LWIP_DBG_OFF
 #define DHCP_DEBUG                  LWIP_DBG_OFF
+
+#define HTTP_HDR_WASM          HTTP_CONTENT_TYPE("application/wasm")
+#define HTTP_HDR_WOFF          HTTP_CONTENT_TYPE("font/woff")
+#define HTTP_HDR_WOFF2         HTTP_CONTENT_TYPE("font/woff2")
+#define HTTP_HDR_TTF           HTTP_CONTENT_TYPE("font/ttf")
+#define HTTP_HDR_OTF           HTTP_CONTENT_TYPE("font/otf")
+#define HTTP_HDR_MAP           HTTP_CONTENT_TYPE("application/json") /* sourcemap */
+#define HTTP_HDR_MJS           HTTP_CONTENT_TYPE("application/javascript")
+
+/* --- WebUI MIME extensions --- */
+#define HTTPD_ADDITIONAL_CONTENT_TYPES \
+  { "wasm",  HTTP_CONTENT_TYPE("application/wasm") }, \
+  { "svg",   HTTP_CONTENT_TYPE("image/svg+xml") }, \
+  { "mjs",   HTTP_CONTENT_TYPE("application/javascript") }, \
+  { "map",   HTTP_CONTENT_TYPE("application/json") }, \
+  { "woff",  HTTP_CONTENT_TYPE("font/woff") }, \
+  { "woff2", HTTP_CONTENT_TYPE("font/woff2") }, \
+  { "ttf",   HTTP_CONTENT_TYPE("font/ttf") }, \
+  { "otf",   HTTP_CONTENT_TYPE("font/otf") }


### PR DESCRIPTION
Currently the server serves some static assets (e.g., .wasm, .svg, and their .gz variants) with Content-Type: text/plain. As a result, browsers may misinterpret these files and fail to load them correctly.

This PR extends the server’s Content-Type mapping to include additional file extensions so that these assets are served with the appropriate Content-Type header.

Why
	•	Ensure browsers correctly interpret and load .wasm, .svg, and other static assets
	•	Improve compatibility when serving pre-compressed (.gz) resources