### PR TITLE
Support for flexiHAL2350 CNC control board from Expatria

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if(AddMyPlugin)
     tmc_uart.c
     my_plugin.c
     boards/pico_cnc.c
+    boards/flexihal2350.c
     boards/btt_skr_pico_10.c
     littlefs/lfs.c
     littlefs/lfs_util.c
@@ -98,6 +99,7 @@ else()
     ioports_analog.c
     tmc_uart.c
     boards/pico_cnc.c
+    boards/flexihal2350.c
     boards/btt_skr_pico_10.c
     littlefs/lfs.c
     littlefs/lfs_util.c

--- a/boards/flexihal2350.c
+++ b/boards/flexihal2350.c
@@ -1,0 +1,121 @@
+/*
+  flexihal2350.c - init code for flexihal2350
+
+  Part of grblHAL
+
+  Copyright (c) 2021-2025 Terje Io
+  Copyright (c) 2025 Expatria Technologies Inc.
+  Copyright (c) 2026 Mitchell Grams
+  
+  grblHAL is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  grblHAL is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with grblHAL. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "driver.h"
+
+#if defined(BOARD_FLEXIHAL2350)
+
+#include "grbl/task.h"
+#include "grbl/state_machine.h"
+
+//static driver_setup_ptr driver_setup;
+
+static control_signals_get_state_ptr hal_control_get_state;
+static stepper_status_t stepper_status = {};
+
+typedef struct {
+    uint8_t n_pins;
+    struct {
+        uint8_t axis;
+        xbar_t  pin;
+    } motor[N_ABC_MOTORS + 3];
+} motor_pins_t;
+
+motor_pins_t fault_signals = {};
+
+void motor_fault_add_pin (input_signal_t *input, xbar_t *pin)
+{
+    fault_signals.motor[fault_signals.n_pins].pin = (xbar_t)*pin;
+    fault_signals.motor[fault_signals.n_pins++].axis = xbar_fault_pin_to_axis(pin->function);
+}
+
+static void poll_motor_fault (void *data)
+{
+    // TODO: use interrupts rather than polling for motor faults
+    stepper_status.fault.state = 0;
+        
+    if(settings.motor_fault_enable.mask) {
+
+        uint_fast8_t idx;
+        xbar_t *pin;
+
+        for(idx = 0; idx < fault_signals.n_pins; idx++) {
+            if(bit_istrue(settings.motor_fault_enable.mask, bit(fault_signals.motor[idx].axis))) {
+
+                pin = &fault_signals.motor[idx].pin;
+
+                if((pin && pin->get_value(pin) != 0.0f)^ bit_istrue(settings.motor_fault_invert.mask, bit(fault_signals.motor[idx].axis)))
+                    xbar_stepper_state_set(&stepper_status.fault, fault_signals.motor[idx].axis, pin->function >= Input_MotorFaultX2);
+            }
+        }
+
+        if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP))) {
+            control_signals_t signals = hal_control_get_state();
+            signals.motor_fault = On;
+            hal.control.interrupt_callback(signals);
+        }
+    }
+
+    task_add_delayed(poll_motor_fault, NULL, 25);
+}
+
+static stepper_status_t getDriverStatus (bool reset)
+{
+    if(reset)
+        stepper_status.fault.state = 0;
+
+    return stepper_status;
+}
+
+static control_signals_t getControlState (void)
+{
+    control_signals_t state = hal_control_get_state();
+
+    state.motor_fault = stepper_status.fault.state != 0;
+
+    return state;
+}
+
+static void driverSetup (void *data)
+{
+    if((hal.signals_cap.motor_fault = !!settings.motor_fault_enable.value && fault_signals.n_pins)) {
+
+        task_add_delayed(poll_motor_fault, NULL, 25);
+
+        hal.stepper.status = getDriverStatus;
+
+        hal_control_get_state = hal.control.get_state;
+        hal.control.get_state = getControlState;
+    }
+}
+
+void board_init (void)
+{
+    task_run_on_startup(driverSetup, NULL);
+
+    // driver_setup = hal.driver_setup;
+    // hal.driver_setup = driverSetup;
+
+}
+
+#endif

--- a/boards/flexihal2350_map.h
+++ b/boards/flexihal2350_map.h
@@ -1,0 +1,236 @@
+/*
+  FlexiHAL 2350 driver pin map
+
+  Part of grblHAL
+
+  Copyright (c) 2024 Terje Io
+  Copyright (c) 2024 PL Barrett
+  Copyright (c) 2025 Expatria Technologies Inc.
+  Copyright (c) 2026 Mitchell Grams
+
+  grblHAL is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  grblHAL is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with grblHAL. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if TRINAMIC_ENABLE
+#error Trinamic plugin not supported!
+#endif
+
+#if N_ABC_MOTORS > 3
+#error "Axis configuration is not supported!"
+#endif
+
+#if RP_MCU != 2350
+#error "Board has a RP2350 processor!"
+#endif
+
+#define BOARD_NAME "FLEXIHAL2350"
+#define BOARD_URL "https://github.com/Expatria-Technologies/FlexiHAL_2350"
+
+#define HAS_BOARD_INIT      1
+
+// Define support for FLEXGPIO RP2040 IO expander
+#if !FLEXGPIO_ENABLE
+#error "Board requires FLEXGPIO expander to be enabled!"
+#endif
+
+#define USE_EXPANDERS       1
+
+#ifdef PICOHAL_IO_ENABLE // need to increase if also using picoHAL IO expander
+#define IOX_PIN_COUNT       32 
+#else
+#define IOX_PIN_COUNT       48
+#endif
+
+#undef I2C_ENABLE
+#undef EEPROM_ENABLE
+#define I2C_ENABLE    1
+#define EEPROM_ENABLE 128
+
+#define LITTLEFS_ENABLE 0
+
+// Define step pulse output pins.
+#define STEP_PORT               GPIO_PIO_1 // Single pin PIO SM
+#define X_STEP_PIN              12
+#define Y_STEP_PIN              14
+#define Z_STEP_PIN              16
+
+// Define step direction output pins.
+#define DIRECTION_PORT          GPIO_OUTPUT
+#define DIRECTION_OUTMODE       GPIO_MAP
+#define X_DIRECTION_PIN         13
+#define Y_DIRECTION_PIN         15
+#define Z_DIRECTION_PIN         17
+
+// Define stepper driver enable/disable output pins.
+#define ENABLE_PORT             EXPANDER_PORT
+#define X_ENABLE_PIN            29 //RP2040 pin
+#define Y_ENABLE_PIN            28 //RP2040 pin
+#define Z_ENABLE_PIN            27 //RP2040 pin
+
+// Define homing/hard limit switch input pins.
+#define X_LIMIT_PIN             38
+#define Y_LIMIT_PIN             37
+#define Z_LIMIT_PIN             36
+#define LIMIT_INMODE            GPIO_MAP
+
+// Define ganged axis or A axis step pulse and step direction output pins.
+#if N_ABC_MOTORS > 0
+#define M3_AVAILABLE
+#define M3_STEP_PIN             18
+#define M3_DIRECTION_PIN        19
+#define M3_LIMIT_PIN            35
+#define M3_ENABLE_PIN           26 //RP2040 pin
+#endif
+
+#if N_ABC_MOTORS >= 2
+#define M4_AVAILABLE
+#define M4_STEP_PIN             20
+#define M4_DIRECTION_PIN        21
+#define M4_LIMIT_PIN            34
+#define M4_ENABLE_PIN           25 //RP2040 pin
+#endif
+
+#if N_ABC_MOTORS == 3
+#define M5_AVAILABLE
+#define M5_STEP_PIN             22
+#define M5_DIRECTION_PIN        23
+#define M5_LIMIT_PIN            34
+#define M5_ENABLE_PIN           24 //RP2040 pin
+#endif
+
+#if COOLANT_ENABLE
+#define COOLANT_PORT            EXPANDER_PORT
+#endif
+#if COOLANT_ENABLE & COOLANT_MIST
+#define COOLANT_MIST_PIN        13 //RP2040 pin
+#endif
+#if COOLANT_ENABLE & COOLANT_FLOOD
+#define COOLANT_FLOOD_PIN       14 //RP2040 pin
+#endif
+
+#if DRIVER_SPINDLE_ENABLE
+#define SPINDLE_PORT               EXPANDER_PORT
+#define SPINDLE_ENABLE_PORT        EXPANDER_PORT
+#define SPINDLE_DIRECTION_PORT     EXPANDER_PORT
+#define SPINDLE_PWM_PORT           GPIO_OUTPUT // Spindle PWM
+#endif
+#if DRIVER_SPINDLE_ENABLE & SPINDLE_ENA
+#define SPINDLE_ENABLE_PIN      11 //RP2040 pin
+#endif
+#if DRIVER_SPINDLE_ENABLE & SPINDLE_PWM
+#define SPINDLE_PWM_PIN         26
+#endif
+#if DRIVER_SPINDLE_ENABLE & SPINDLE_DIR
+#define SPINDLE_DIRECTION_PIN   12 //RP2040 pin
+#endif
+
+#define AUXINPUT0_PIN           47  // Encoder 2
+#define AUXINPUT1_PIN           46  // Encoder 2
+#define AUXINPUT2_PIN           45  // Encoder 2
+
+#define AUXINPUT3_PIN           9   // Encoder 1
+#define AUXINPUT4_PIN           10  // Encoder 1
+#define AUXINPUT5_PIN           11  // Encoder 1
+
+#define AUXINPUT6_PIN           24  // Reset / HALT
+#define AUXINPUT7_PIN           27  // Feed Hold / HD
+#define AUXINPUT8_PIN           32  // Safety door / DR
+#define AUXINPUT9_PIN           30  // Cycle Start / RN
+
+#define AUXINPUT10_PIN          8   // I2C strobe pin
+#define AUXINPUT11_PIN          31  // Expander MCU_IRQ Pin
+//#define AUXINPUT12_PIN        39  // Probe
+
+// Define user-control controls (cycle start, reset, feed hold) input pins.
+#if CONTROL_ENABLE & CONTROL_HALT
+#define RESET_PIN               AUXINPUT6_PIN
+#endif
+#if CONTROL_ENABLE & CONTROL_FEED_HOLD
+#define FEED_HOLD_PIN           AUXINPUT7_PIN
+#endif
+#if CONTROL_ENABLE & CONTROL_CYCLE_START
+#define CYCLE_START_PIN         AUXINPUT9_PIN
+#endif
+
+#if SAFETY_DOOR_ENABLE
+#define SAFETY_DOOR_PIN         AUXINPUT8_PIN
+#endif
+
+#if TOOLSETTER_ENABLE
+#define TOOLSETTER_PORT         EXPANDER_PORT
+#define TOOLSETTER_PIN          3 //RP2040 pin
+#endif
+
+#if PROBE_ENABLE
+#define PROBE_PORT              EXPANDER_PORT
+#define PROBE_PIN               4 //RP2040 pin
+#endif
+
+#if I2C_STROBE_ENABLE
+#define I2C_STROBE_PIN          AUXINPUT10_PIN
+#endif
+
+#if FLEXGPIO_IRQ_ENABLE
+#define FLEXGPIO_IRQ_PIN        11 //AUXINPUT NUMBER
+#endif
+
+// /Define per axis fault pins on expander
+#define MOTOR_FAULT_PORT            EXPANDER_PORT
+#define X_MOTOR_FAULT_PIN           5  //RP2040 pin
+#define Y_MOTOR_FAULT_PIN           6  //RP2040 pin
+#define Z_MOTOR_FAULT_PIN           7  //RP2040 pin
+#if N_ABC_MOTORS > 0
+  #define M3_MOTOR_FAULT_PIN        8  //RP2040 pin
+#endif
+#if N_ABC_MOTORS >= 2
+  #define M4_MOTOR_FAULT_PIN        9  //RP2040 pin
+#endif
+#if N_ABC_MOTORS == 3
+  #define M5_MOTOR_FAULT_PIN        10 //RP2040 pin
+#endif
+
+#if SDCARD_ENABLE || ETHERNET_ENABLE
+
+#define SPI_PORT                0
+#define SPI_SCK_PIN             2
+#define SPI_MOSI_PIN            3
+#define SPI_MISO_PIN            0
+#define SD_CS_PIN               44
+
+#if ETHERNET_ENABLE
+#define SPI_CS_PIN              33
+#define SPI_IRQ_PIN             25
+#endif
+
+#endif // SDCARD_ENABLE || ETHERNET_ENABLE
+
+#if I2C_ENABLE
+#define I2C_PORT                1
+#define I2C_SDA                 6    
+#define I2C_SCL                 7
+#endif
+
+// UART 0 (MODBUS)
+#if MODBUS_ENABLE
+#define MODBUS_RTU_STREAM       0
+//#define UART_PORT               uart0
+#define UART_TX_PIN             28
+#define UART_RX_PIN             29
+#endif
+
+// UART 1 (RPI)
+#define SERIAL1_PORT            1
+//#define UART_1_PORT             uart1
+#define UART_1_TX_PIN           4
+#define UART_1_RX_PIN           5

--- a/driver.c
+++ b/driver.c
@@ -349,7 +349,19 @@ static input_signal_t inputpin[] = {
     { .id = Input_Aux10, .port = GPIO_INPUT, .pin = AUXINPUT10_PIN, .group = PinGroup_AuxInput },
 #endif
 #ifdef AUXINPUT11_PIN
-    { .id = Input_Aux11, .port = GPIO_INPUT, .pin = AUXINPUT11_PIN, .group = PinGroup_AuxInput }
+    { .id = Input_Aux11, .port = GPIO_INPUT, .pin = AUXINPUT11_PIN, .group = PinGroup_AuxInput },
+#endif
+#ifdef AUXINPUT12_PIN
+    { .id = Input_Aux12, .port = GPIO_INPUT, .pin = AUXINPUT12_PIN, .group = PinGroup_AuxInput },
+#endif
+#ifdef AUXINPUT13_PIN
+    { .id = Input_Aux13, .port = GPIO_INPUT, .pin = AUXINPUT13_PIN, .group = PinGroup_AuxInput },
+#endif
+#ifdef AUXINPUT14_PIN
+    { .id = Input_Aux14, .port = GPIO_INPUT, .pin = AUXINPUT14_PIN, .group = PinGroup_AuxInput },
+#endif
+#ifdef AUXINPUT15_PIN
+    { .id = Input_Aux15, .port = GPIO_INPUT, .pin = AUXINPUT15_PIN, .group = PinGroup_AuxInput }
 #endif
 };
 
@@ -3195,6 +3207,7 @@ bool driver_init (void)
 
     hal.limits_cap = get_limits_cap();
     hal.home_cap = get_home_cap();
+    hal.motor_fault_cap = get_motor_fault_cap();
 #if defined(COOLANT_FLOOD_PIN) || OUT_SHIFT_REGISTER
     hal.coolant_cap.flood = On;
 #endif

--- a/driver.c
+++ b/driver.c
@@ -301,19 +301,13 @@ static input_signal_t inputpin[] = {
     add_limit_pin(W)
 #endif
 #ifdef A_LIMIT_PIN_MAX
-    { .id = Input_LimitA_Max,     .port = GPIO_INPUT, .pin = A_LIMIT_PIN_MAX,     .group = PinGroup_Limit },
-#endif
-#ifdef B_LIMIT_PIN
-    { .id = Input_LimitB,         .port = GPIO_INPUT, .pin = B_LIMIT_PIN,         .group = PinGroup_Limit },
+    add_maxlimit_pin(A)
 #endif
 #ifdef B_LIMIT_PIN_MAX
-    { .id = Input_LimitB_Max,     .port = GPIO_INPUT, .pin = B_LIMIT_PIN_MAX,     .group = PinGroup_Limit },
-#endif
-#ifdef C_LIMIT_PIN
-    { .id = Input_LimitC,         .port = GPIO_INPUT, .pin = C_LIMIT_PIN,         .group = PinGroup_Limit },
+    add_maxlimit_pin(B)
 #endif
 #ifdef C_LIMIT_PIN_MAX
-    { .id = Input_LimitC_Max,     .port = GPIO_INPUT, .pin = C_LIMIT_PIN_MAX,     .group = PinGroup_Limit },
+   add_maxlimit_pin(C)
 #endif
 #ifdef SPI_IRQ_PIN
     { .id = Input_SPIIRQ,    .port = GPIO_INPUT, .pin = SPI_IRQ_PIN,    .group = PinGroup_SPI },

--- a/driver.h
+++ b/driver.h
@@ -169,7 +169,9 @@
 #elif defined(BOARD_PICOBOB_DLX_G540)
   #include "boards/picobob_dlx_g540_map.h"
 #elif defined(BOARD_PICOHAL)
-  #include "boards/picohal_map.h"        
+  #include "boards/picohal_map.h"
+#elif defined(BOARD_FLEXIHAL2350)
+  #include "boards/flexihal2350_map.h"             
 #elif defined(BOARD_BTT_SKR_PICO_10) || defined(BOARD_BTT_SKR_PICO_10_HOTWIRE)
   #include "boards/btt_skr_pico_10_map.h"
 #elif defined BOARD_CITOH_CX6000

--- a/driver.json
+++ b/driver.json
@@ -225,7 +225,25 @@
           "RP_MCU": "2350"
       }
     },
-	{
+    {
+      "name": "FlexiHAL2350",
+      "symbol": "BOARD_FLEXIHAL2350",
+      "URL": "https://github.com/Expatria-Technologies/FlexiHAL_2350",
+      "MAP": "boards/flexihal2350_map.h",
+      "caps": {
+        "axes": 6,
+        "digital_in": 14,
+        "digital_out": 12,
+        "i2c_strobe": 1,
+        "eeprom": 1,
+        "fram": 1,
+        "i2c": 1,
+        "sdcard": 1,
+        "serial_ports": 2,
+        "wiznet": 5500
+      }
+    },
+    {
       "name": "Generic",
       "symbol": "",
       "MAP": "boards/generic_map.h",
@@ -248,7 +266,7 @@
         "bluetooth": 1
       }
     },
-	{
+    {
       "name": "Generic w/RP2350",
       "symbol": "",
       "MAP": "boards/generic_map.h",


### PR DESCRIPTION
Provide initial support for 6-axis [FlexiHAL2350](https://github.com/Expatria-Technologies/FlexiHAL_2350) CNC control board:
- 12x aux inputs (gpio)
- 6x motor alarm (via expander)
- 2x aux inputs / probe (via expander)
- 8x aux outputs + 2x flood + 2x spindle en/dir + 6x motor enable (via expander)

To facilitate use of on-board RP2040 i2c IO using the [FlexGPIO plugin](https://github.com/engigeer/Plugins_misc/blob/PR_FLEXGPIO/flexgpio_expander.c), changes are included to enable explicit claiming of expander inputs.

PR also includes some minor bug fixes for reporting of UF2 bootloader plugin and AB limit pins.