### PR TITLE
Add $REBOOT support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ target_link_libraries(grblHAL PRIVATE
  tinyusb_device_unmarked
  pico_stdlib
  pico_unique_id
+ cmsis_core
  hardware_dma
  hardware_uart
  hardware_pio

--- a/driver.c
+++ b/driver.c
@@ -3108,6 +3108,8 @@ bool driver_init (void)
 
     hal.control.get_state = systemGetState;
 
+    hal.reboot = __NVIC_SystemReset;
+    
 #if I2C_STROBE_ENABLE || SPI_IRQ_BIT
     hal.irq_claim = irq_claim;
 #endif

--- a/driver.h
+++ b/driver.h
@@ -27,6 +27,12 @@
 #ifndef __DRIVER_H__
 #define __DRIVER_H__
 
+#if RP_MCU == 2040
+#include "RP2040.h"
+#elif RP_MCU == 2350
+#include "RP2350.h"
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -309,19 +315,19 @@ void pinEnableIRQ (const input_signal_t *input, pin_irq_mode_t irq_mode);
 
 // While waiting for CMSIS headers...:
 
-static inline void __enable_irq(void)
-{
-  __asm volatile ("cpsie i" : : : "memory");
-}
+// static inline void __enable_irq(void)
+// {
+//   __asm volatile ("cpsie i" : : : "memory");
+// }
 
 /**
   \brief   Disable IRQ Interrupts
   \details Disables IRQ interrupts by setting the I-bit in the CPSR.
            Can only be executed in Privileged modes.
  */
-static inline  void __disable_irq(void)
-{
-  __asm volatile ("cpsid i" : : : "memory");
-}
+// static inline  void __disable_irq(void)
+// {
+//   __asm volatile ("cpsid i" : : : "memory");
+// }
 
 #endif // __DRIVER_H__


### PR DESCRIPTION
Add support for `$REBOOT` command via `__NVIC_SystemReset`. This requires using the *cmsis_core* headers which are now available in the Pico_SDK and just needed to be linked in *CMakeLists*.

`__enable_irq` / `__disable_irq` functions are also available in *cmsis_core* headers so existing definitions have been commented out, but maybe could even be removed entirely.