### PR TITLE
PR flexi2350 support for probing and motor fault

### DIFF
--- a/boards/flexihal2350.c
+++ b/boards/flexihal2350.c
@@ -43,10 +43,12 @@ typedef struct {
 
 motor_pins_t fault_signals = {};
 
-void motor_fault_add_pin (input_signal_t *input, xbar_t *pin)
+void input_add_expander_pin (xbar_t *input)
 {
-    fault_signals.motor[fault_signals.n_pins].pin = (xbar_t)*pin;
-    fault_signals.motor[fault_signals.n_pins++].axis = xbar_fault_pin_to_axis(pin->function);
+    if(xbar_is_motor_fault_in(input->function)){
+        fault_signals.motor[fault_signals.n_pins].pin = (xbar_t)*input;
+        fault_signals.motor[fault_signals.n_pins++].axis = xbar_fault_pin_to_axis(input->function);
+    }
 }
 
 static void poll_motor_fault (void *data)

--- a/boards/flexihal2350.c
+++ b/boards/flexihal2350.c
@@ -25,8 +25,10 @@
 
 #if defined(BOARD_FLEXIHAL2350)
 
+#include "grbl/hal.h"
 #include "grbl/task.h"
 #include "grbl/state_machine.h"
+#include "grbl/pin_bits_masks.h"
 
 //static driver_setup_ptr driver_setup;
 
@@ -42,6 +44,15 @@ typedef struct {
 } motor_pins_t;
 
 motor_pins_t fault_signals = {};
+
+static probe_select_ptr probe_select;
+static probe_configure_ptr probe_configure;
+
+probe_id_t active_probe = Probe_Default;
+
+// TODO: add code guards and assign pins based on board map instead of hardcoding?
+aux_ctrl_t probe_pin = { .function = Input_Probe, .port = IOPORT_UNASSIGNED, .gpio.pin = 4 };
+aux_ctrl_t toolsetter_pin = { .function = Input_Toolsetter, .port = IOPORT_UNASSIGNED, .gpio.pin = 3 };
 
 void input_add_expander_pin (xbar_t *input)
 {
@@ -111,6 +122,79 @@ static void driverSetup (void *data)
     }
 }
 
+bool onProbeSelect (probe_id_t probe_id)
+{
+    gpio_in_config_t config0 = {0};
+    gpio_in_config_t config1 = {0};
+
+    switch(probe_id) {
+
+        case Probe_Default:
+            ioport_enable_irq(probe_pin.port, (pin_irq_mode_t)IRQ_Mode_All, NULL);
+            ioport_enable_irq(toolsetter_pin.port, (pin_irq_mode_t)IRQ_Mode_None, NULL);
+            break;    
+
+        case Probe_Toolsetter:
+            ioport_enable_irq(probe_pin.port, (pin_irq_mode_t)IRQ_Mode_None, NULL);
+            ioport_enable_irq(toolsetter_pin.port, (pin_irq_mode_t)IRQ_Mode_All, NULL);
+            break;
+
+        default:
+            return false;
+    }
+
+    active_probe = probe_id;
+    hal.probe.configure(false, false);
+
+    return true;
+}
+
+static void probeConfigure (bool is_probe_away, bool probing)
+{
+    if (active_probe == Probe_Toolsetter) {
+        if (settings.probe.invert_toolsetter_input != settings.probe.invert_probe_pin)
+            is_probe_away = !is_probe_away; // invert here only if toolsetter invert setting is different from probe invert setting
+    }
+    probe_configure(is_probe_away, probing);
+}
+
+#if PROBE_ENABLE == 2 && NGC_PARAMETERS_ENABLE
+
+void probe_select_init (void)
+{
+    bool ok = true;
+    xbar_t *pin;
+
+    if(ioports_enumerate(Port_Digital, Port_Input, (pin_cap_t){.external = On, .claimable = On }, __find_in_ext, &probe_pin)){
+        if(pin = ioport_claim(Port_Digital, Port_Input, &probe_pin.port, NULL)) {
+            ioport_set_description(Port_Digital, Port_Input, probe_pin.port, "expander multiplex");
+            ioport_set_function(pin, probe_pin.function, NULL);
+        }
+    } else 
+        ok = false;
+
+    if(ioports_enumerate(Port_Digital, Port_Input, (pin_cap_t){.external = On, .claimable = On }, __find_in_ext, &toolsetter_pin)){
+        if(pin = ioport_claim(Port_Digital, Port_Input, &toolsetter_pin.port, NULL)) {
+            ioport_set_description(Port_Digital, Port_Input, toolsetter_pin.port, "expander multiplex");
+            ioport_set_function(pin, toolsetter_pin.function, NULL);
+        }
+    } else 
+        ok = false;
+    
+    if(ok && (hal.driver_cap.toolsetter = On)) {
+        probe_select = hal.probe.select;
+        hal.probe.select = onProbeSelect;
+
+        probe_configure = hal.probe.configure;
+        hal.probe.configure = probeConfigure;
+
+    } else
+        task_run_on_startup(report_warning, "Probe expander plugin: error claiming required ports.");
+
+}
+
+#endif // PROBE_ENABLE == 2 && NGC_PARAMETERS_ENABLE
+
 void board_init (void)
 {
     task_run_on_startup(driverSetup, NULL);
@@ -120,4 +204,4 @@ void board_init (void)
 
 }
 
-#endif
+#endif // BOARD_FLEXIHAL2350

--- a/boards/flexihal2350.c
+++ b/boards/flexihal2350.c
@@ -120,13 +120,13 @@ static void driverSetup (void *data)
         hal_control_get_state = hal.control.get_state;
         hal.control.get_state = getControlState;
     }
+
+    if(hal.probe.select)
+        hal.probe.select(Probe_Default);
 }
 
 bool onProbeSelect (probe_id_t probe_id)
 {
-    gpio_in_config_t config0 = {0};
-    gpio_in_config_t config1 = {0};
-
     switch(probe_id) {
 
         case Probe_Default:

--- a/boards/flexihal2350_map.h
+++ b/boards/flexihal2350_map.h
@@ -46,12 +46,6 @@
 
 #define USE_EXPANDERS       1
 
-#ifdef PICOHAL_IO_ENABLE // need to increase if also using picoHAL IO expander
-#define IOX_PIN_COUNT       32 
-#else
-#define IOX_PIN_COUNT       48
-#endif
-
 #undef I2C_ENABLE
 #undef EEPROM_ENABLE
 #define I2C_ENABLE    1
@@ -150,7 +144,6 @@
 
 #define AUXINPUT10_PIN          8   // I2C strobe pin
 #define AUXINPUT11_PIN          31  // Expander MCU_IRQ Pin
-//#define AUXINPUT12_PIN        39  // Probe
 
 // Define user-control controls (cycle start, reset, feed hold) input pins.
 #if CONTROL_ENABLE & CONTROL_HALT
@@ -167,14 +160,9 @@
 #define SAFETY_DOOR_PIN         AUXINPUT8_PIN
 #endif
 
-#if TOOLSETTER_ENABLE
-#define TOOLSETTER_PORT         EXPANDER_PORT
-#define TOOLSETTER_PIN          3 //RP2040 pin
-#endif
-
-#if PROBE_ENABLE
-#define PROBE_PORT              EXPANDER_PORT
-#define PROBE_PIN               4 //RP2040 pin
+#if PROBE_ENABLE == 2
+#define AUXINPUT12_PIN          39  // Probe
+#define PROBE_PIN               AUXINPUT12_PIN
 #endif
 
 #if I2C_STROBE_ENABLE

--- a/driver.c
+++ b/driver.c
@@ -214,7 +214,7 @@ static volatile uint32_t elapsed_ticks = 0;
 static pin_group_pins_t limit_inputs;
 
 #ifdef USE_EXPANDERS
-xbar_t *iox_out[N_AUX_DOUT_MAX] = {};
+xbar_t *iox_out[N_AUX_DOUT] = {};
 #endif
 
 #ifdef NEOPIXELS_PIN

--- a/driver_spindles.c
+++ b/driver_spindles.c
@@ -31,7 +31,7 @@
 #include "grbl/task.h"
 
 #ifdef USE_EXPANDERS
-extern xbar_t *iox_out[N_AUX_DOUT_MAX];
+extern xbar_t *iox_out[N_AUX_DOUT];
 #endif
 
 #if PPI_ENABLE


### PR DESCRIPTION
### Key Changes
- add support in board specific code motor fault pin assignment from flexGPIO expander
- add support for probe selection using probe + toolsetter from expander
- update board map with support for probe select

Also, a change is proposed for sizing `IOX_OUT` based on `N_AUX_DOUT` rather than `N_AUX_DOUT_MAX`. This enables use of expander pin numbers that exceed `N_AUX_DOUT_MAX` simply by specifying a large value `N_AUX_DOUT` at compile time. Primary use case is simultaneously enabling flexGPIO plugin and other expanders (i.e., picoHAL).

FlexGPIO plugin code is available [here](https://github.com/Expatria-Technologies/plugin_FlexGPIO).