### PR TITLE
Update for Flexi2350 compatibility with webbuilder

### DIFF
--- a/driver.json
+++ b/driver.json
@@ -247,8 +247,8 @@
       },
       "symbols": {
           "RP_MCU": "2350",
-          "PROBE_ENABLE": 2,
-          "FLEXGPIO_ENABLE": 1
+          "N_AUX_DIN": 40,
+          "N_AUX_DOUT": 40
       }
     },
     {


### PR DESCRIPTION
It seems that perhaps including `PROBE_ENABLE = 2` and `FLEXGPIO_ENABLE = 1` are not necessary since these flags are already produced by selecting the checkboxes for **Probe Relays** under the plugins tab and the **FlexGPIO I2C I/O expander** under I/O Expansion tab. The latter appears to be automatically selected, so perhaps it is possible to do the same for Probe Relays?

I have also added two definitions which are necessary to prevent issues with the Flexi2350 board due to the large amount of IO.