### PR TITLE
Removed A_ENABLE_PORT/PIN and Added Shift Register OE pin to board driver

### DIFF
--- a/boards/slblite.c
+++ b/boards/slblite.c
@@ -23,9 +23,21 @@
 
 #if defined(HAS_BOARD_INIT) && defined(BOARD_SLB_LITE)
 
+#include "grbl/task.h"
+
+// Shift register Output Enable — pulled LOW at boot to enable 74HCT595 outputs.
+// task_run_on_startup pattern from Ooznest example:
+// https://github.com/Ooznest/ESP32/blob/master/main/boards/ooznest_cnc.c
+static void sr_oe_init (void *arg)
+{
+    gpio_init(OUT_SR_OE_PIN);
+    gpio_set_dir(OUT_SR_OE_PIN, GPIO_OUT);
+    gpio_put(OUT_SR_OE_PIN, 0);
+}
+
 void board_init (void)
 {
-  // Blank Template
+    task_run_on_startup(sr_oe_init, NULL);
 }
 
 #endif // defined(HAS_BOARD_INIT) && defined(BOARD_SLB_LITE)

--- a/boards/slblite_map.h
+++ b/boards/slblite_map.h
@@ -65,6 +65,7 @@
 #define OUT_SHIFT_REGISTER       8 // How many bits are used in the shift register, 8 for 74HCT595
 #define OUT_SR_DATA_PIN         32 // Data Pin
 #define OUT_SR_SCK_PIN          33 // Clock Pin (includes next pin (34) automatically as Latch)
+#define OUT_SR_OE_PIN           26 // Output Enable (active low)
 
 // Define step pulse output pins: PIO Peripheral: Define Base Pin and then consecutive pins for the number of axes are assigned automatically
 #define STEP_PORT               GPIO_PIO  // N_AXIS pin PIO SM

--- a/boards/slblite_map.h
+++ b/boards/slblite_map.h
@@ -82,8 +82,6 @@
 #define XY_ENABLE_PIN           0
 #define Z_ENABLE_PORT           EXPANDER_PORT
 #define Z_ENABLE_PIN            1
-#define A_ENABLE_PORT           EXPANDER_PORT
-#define A_ENABLE_PIN            1
 
 // Define homing/hard limit switch input pins.
 #define X_LIMIT_PIN             6


### PR DESCRIPTION
Per your message "SLBLITE does not compile - remove A_ENABLE_PORT and PIN, enable signals for M3 and M4 are not needed. When needed add as M3_ENABLE_PORT and PIN and M4_ENABLE_PORT and PIN." - I removed them 

I also took a knack at adding a startup task to set the Shift Register OE pin. 
