### PR TITLE
Motor fault irq

### DIFF
--- a/boards/slblite.c
+++ b/boards/slblite.c
@@ -24,28 +24,58 @@
 #if defined(HAS_BOARD_INIT) && defined(BOARD_SLB_LITE)
 
 #include "grbl/task.h"
+#include "grbl/system.h"
 #include "grbl/state_machine.h"
 #include "grbl/core_handlers.h"
 
-static control_signals_get_state_ptr hal_control_get_state;
 static stepper_status_t stepper_status = {};
-
-typedef struct {
-    uint8_t n_pins;
-    struct {
-        uint8_t axis;
-        bool secondary;
-        input_signal_t *input;
-    } motor[N_ABC_MOTORS + 3];
-} motor_pins_t;
-
-static motor_pins_t fault_signals = {};
+static const bool motor_fault_invert = true;
+static const uint8_t fault_pins[] = {
+    SLBLITE_X_MOTOR_FAULT_PIN,
+    SLBLITE_Y_MOTOR_FAULT_PIN,
+    SLBLITE_Z_MOTOR_FAULT_PIN,
+#ifdef SLBLITE_M3_MOTOR_FAULT_PIN
+    SLBLITE_M3_MOTOR_FAULT_PIN,
+#endif
+#ifdef SLBLITE_M4_MOTOR_FAULT_PIN
+    SLBLITE_M4_MOTOR_FAULT_PIN,
+#endif
+};
+#if NUM_BANK0_GPIOS > 32
+static const uint64_t fault_pin_mask =
+    (1ull << SLBLITE_X_MOTOR_FAULT_PIN) |
+    (1ull << SLBLITE_Y_MOTOR_FAULT_PIN) |
+    (1ull << SLBLITE_Z_MOTOR_FAULT_PIN)
+#ifdef SLBLITE_M3_MOTOR_FAULT_PIN
+    | (1ull << SLBLITE_M3_MOTOR_FAULT_PIN)
+#endif
+#ifdef SLBLITE_M4_MOTOR_FAULT_PIN
+    | (1ull << SLBLITE_M4_MOTOR_FAULT_PIN)
+#endif
+    ;
+#else
+static const uint32_t fault_pin_mask =
+    (1u << SLBLITE_X_MOTOR_FAULT_PIN) |
+    (1u << SLBLITE_Y_MOTOR_FAULT_PIN) |
+    (1u << SLBLITE_Z_MOTOR_FAULT_PIN)
+#ifdef SLBLITE_M3_MOTOR_FAULT_PIN
+    | (1u << SLBLITE_M3_MOTOR_FAULT_PIN)
+#endif
+#ifdef SLBLITE_M4_MOTOR_FAULT_PIN
+    | (1u << SLBLITE_M4_MOTOR_FAULT_PIN)
+#endif
+    ;
+#endif
 
 void motor_fault_add_pin (input_signal_t *input, xbar_t *pin)
 {
-    fault_signals.motor[fault_signals.n_pins].input = input;
-    fault_signals.motor[fault_signals.n_pins].axis = xbar_fault_pin_to_axis(pin->function);
-    fault_signals.motor[fault_signals.n_pins++].secondary = pin->function >= Input_MotorFaultX2;
+    (void)input;
+    (void)pin;
+}
+
+static bool motor_fault_active (uint8_t pin)
+{
+    return (DIGITAL_IN(pin) != 0) ^ motor_fault_invert;
 }
 
 static void update_motor_fault_status (void)
@@ -54,33 +84,35 @@ static void update_motor_fault_status (void)
 
     stepper_status.fault.state = 0;
 
-    if(!settings.motor_fault_enable.mask)
-        return;
-
-    for(idx = 0; idx < fault_signals.n_pins; idx++) {
-
-        if(bit_istrue(settings.motor_fault_enable.mask, bit(fault_signals.motor[idx].axis))) {
-
-            input_signal_t *input = fault_signals.motor[idx].input;
-            bool inverted = bit_istrue(settings.motor_fault_invert.mask, bit(fault_signals.motor[idx].axis));
-
-            if((DIGITAL_IN(input->pin) != 0) ^ inverted)
-                xbar_stepper_state_set(&stepper_status.fault, fault_signals.motor[idx].axis, fault_signals.motor[idx].secondary);
+    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
+        if(motor_fault_active(fault_pins[idx])) {
+            stepper_status.fault.state = 1;
+            break;
         }
     }
 }
 
-static void motor_fault_irq_handler (uint8_t port, bool state)
+static void motor_fault_irq_handler (void)
 {
-    (void)port;
-    (void)state;
+    uint_fast8_t idx;
+    bool changed = false;
+
+    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
+        uint32_t events = gpio_get_irq_event_mask(fault_pins[idx]);
+
+        if(events) {
+            gpio_acknowledge_irq(fault_pins[idx], events);
+            changed = true;
+        }
+    }
+
+    if(!changed)
+        return;
 
     update_motor_fault_status();
 
     if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP))) {
-        control_signals_t signals = hal_control_get_state();
-        signals.motor_fault = On;
-        hal.control.interrupt_callback(signals);
+        system_set_exec_alarm(Alarm_MotorFault);
     }
 }
 
@@ -94,38 +126,29 @@ static stepper_status_t getDriverStatus (bool reset)
     return stepper_status;
 }
 
-static control_signals_t getControlState (void)
-{
-    control_signals_t state = hal_control_get_state();
-
-    update_motor_fault_status();
-    state.motor_fault = stepper_status.fault.state != 0;
-
-    return state;
-}
-
 static void motor_fault_init (void *arg)
 {
     uint_fast8_t idx;
 
-    if(!fault_signals.n_pins)
-        return;
-
-    hal.signals_cap.motor_fault = On;
     hal.stepper.status = getDriverStatus;
 
-    hal_control_get_state = hal.control.get_state;
-    hal.control.get_state = getControlState;
-
-    for(idx = 0; idx < fault_signals.n_pins; idx++) {
-        input_signal_t *input = fault_signals.motor[idx].input;
-
-        input->mode.irq_mode = IRQ_Mode_Change;
-        input->interrupt_callback = motor_fault_irq_handler;
-        pinEnableIRQ(input, input->mode.irq_mode);
+    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
+        gpio_init(fault_pins[idx]);
+        gpio_set_dir(fault_pins[idx], GPIO_IN);
+        gpio_set_irq_enabled(fault_pins[idx], GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);
     }
 
+#if NUM_BANK0_GPIOS > 32
+    gpio_add_raw_irq_handler_masked64(fault_pin_mask, motor_fault_irq_handler);
+#else
+    gpio_add_raw_irq_handler_masked(fault_pin_mask, motor_fault_irq_handler);
+#endif
+    irq_set_enabled(IO_IRQ_BANK0, true);
+
     update_motor_fault_status();
+
+    if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP)))
+        system_set_exec_alarm(Alarm_MotorFault);
 }
 
 // Shift register Output Enable — pulled LOW at boot to enable 74HCT595 outputs.

--- a/boards/slblite.c
+++ b/boards/slblite.c
@@ -28,8 +28,11 @@
 #include "grbl/state_machine.h"
 #include "grbl/core_handlers.h"
 
+#define MOTOR_FAULT_ARM_DELAY_MS 1000
+
 static stepper_status_t stepper_status = {};
 static const bool motor_fault_invert = true;
+static volatile bool motor_fault_armed = false;
 static const uint8_t fault_pins[] = {
     SLBLITE_X_MOTOR_FAULT_PIN,
     SLBLITE_Y_MOTOR_FAULT_PIN,
@@ -84,6 +87,9 @@ static void update_motor_fault_status (void)
 
     stepper_status.fault.state = 0;
 
+    if(!motor_fault_armed)
+        return;
+
     for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
         if(motor_fault_active(fault_pins[idx])) {
             stepper_status.fault.state = 1;
@@ -116,11 +122,28 @@ static void motor_fault_irq_handler (void)
     }
 }
 
+static void arm_motor_fault_monitor (void *data)
+{
+    uint_fast8_t idx;
+
+    (void)data;
+
+    motor_fault_armed = true;
+
+    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++)
+        gpio_set_irq_enabled(fault_pins[idx], GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);
+
+    update_motor_fault_status();
+
+    if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP)))
+        system_set_exec_alarm(Alarm_MotorFault);
+}
+
 static stepper_status_t getDriverStatus (bool reset)
 {
     if(reset)
         stepper_status.fault.state = 0;
-    else
+    else if(motor_fault_armed)
         update_motor_fault_status();
 
     return stepper_status;
@@ -131,11 +154,12 @@ static void motor_fault_init (void *arg)
     uint_fast8_t idx;
 
     hal.stepper.status = getDriverStatus;
+    motor_fault_armed = false;
 
     for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
         gpio_init(fault_pins[idx]);
         gpio_set_dir(fault_pins[idx], GPIO_IN);
-        gpio_set_irq_enabled(fault_pins[idx], GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);
+        gpio_set_irq_enabled(fault_pins[idx], GPIO_IRQ_ALL, false);
     }
 
 #if NUM_BANK0_GPIOS > 32
@@ -145,10 +169,7 @@ static void motor_fault_init (void *arg)
 #endif
     irq_set_enabled(IO_IRQ_BANK0, true);
 
-    update_motor_fault_status();
-
-    if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP)))
-        system_set_exec_alarm(Alarm_MotorFault);
+    task_add_delayed(arm_motor_fault_monitor, NULL, MOTOR_FAULT_ARM_DELAY_MS);
 }
 
 // Shift register Output Enable — pulled LOW at boot to enable 74HCT595 outputs.

--- a/boards/slblite.c
+++ b/boards/slblite.c
@@ -24,48 +24,48 @@
 #if defined(HAS_BOARD_INIT) && defined(BOARD_SLB_LITE)
 
 #include "grbl/task.h"
-#include "grbl/system.h"
 #include "grbl/state_machine.h"
-#include "grbl/core_handlers.h"
 
 #define MOTOR_FAULT_ARM_DELAY_MS 1000
 
+static driver_setup_ptr driver_setup;
+static control_signals_get_state_ptr hal_control_get_state;
 static stepper_status_t stepper_status = {};
-static const bool motor_fault_invert = true;
 static volatile bool motor_fault_armed = false;
-static const uint8_t fault_pins[] = {
-    SLBLITE_X_MOTOR_FAULT_PIN,
-    SLBLITE_Y_MOTOR_FAULT_PIN,
-    SLBLITE_Z_MOTOR_FAULT_PIN,
-#ifdef SLBLITE_M3_MOTOR_FAULT_PIN
-    SLBLITE_M3_MOTOR_FAULT_PIN,
-#endif
-#ifdef SLBLITE_M4_MOTOR_FAULT_PIN
-    SLBLITE_M4_MOTOR_FAULT_PIN,
-#endif
-};
+static bool motor_fault_initialized = false;
+static bool motor_fault_irq_installed = false;
+typedef struct {
+    uint8_t n_pins;
+    struct {
+        uint8_t axis;
+        bool secondary;
+        uint8_t pin;
+    } motor[N_ABC_MOTORS + 3];
+} motor_pins_t;
+
+static motor_pins_t fault_signals = {};
 #if NUM_BANK0_GPIOS > 32
 static const uint64_t fault_pin_mask =
-    (1ull << SLBLITE_X_MOTOR_FAULT_PIN) |
-    (1ull << SLBLITE_Y_MOTOR_FAULT_PIN) |
-    (1ull << SLBLITE_Z_MOTOR_FAULT_PIN)
-#ifdef SLBLITE_M3_MOTOR_FAULT_PIN
-    | (1ull << SLBLITE_M3_MOTOR_FAULT_PIN)
+    (1ull << X_MOTOR_FAULT_PIN) |
+    (1ull << Y_MOTOR_FAULT_PIN) |
+    (1ull << Z_MOTOR_FAULT_PIN)
+#ifdef M3_MOTOR_FAULT_PIN
+    | (1ull << M3_MOTOR_FAULT_PIN)
 #endif
-#ifdef SLBLITE_M4_MOTOR_FAULT_PIN
-    | (1ull << SLBLITE_M4_MOTOR_FAULT_PIN)
+#ifdef M4_MOTOR_FAULT_PIN
+    | (1ull << M4_MOTOR_FAULT_PIN)
 #endif
     ;
 #else
 static const uint32_t fault_pin_mask =
-    (1u << SLBLITE_X_MOTOR_FAULT_PIN) |
-    (1u << SLBLITE_Y_MOTOR_FAULT_PIN) |
-    (1u << SLBLITE_Z_MOTOR_FAULT_PIN)
-#ifdef SLBLITE_M3_MOTOR_FAULT_PIN
-    | (1u << SLBLITE_M3_MOTOR_FAULT_PIN)
+    (1u << X_MOTOR_FAULT_PIN) |
+    (1u << Y_MOTOR_FAULT_PIN) |
+    (1u << Z_MOTOR_FAULT_PIN)
+#ifdef M3_MOTOR_FAULT_PIN
+    | (1u << M3_MOTOR_FAULT_PIN)
 #endif
-#ifdef SLBLITE_M4_MOTOR_FAULT_PIN
-    | (1u << SLBLITE_M4_MOTOR_FAULT_PIN)
+#ifdef M4_MOTOR_FAULT_PIN
+    | (1u << M4_MOTOR_FAULT_PIN)
 #endif
     ;
 #endif
@@ -76,25 +76,70 @@ void motor_fault_add_pin (input_signal_t *input, xbar_t *pin)
     (void)pin;
 }
 
-static bool motor_fault_active (uint8_t pin)
+static void motor_fault_register_pin (uint8_t axis, bool secondary, uint8_t pin)
 {
-    return (DIGITAL_IN(pin) != 0) ^ motor_fault_invert;
+    fault_signals.motor[fault_signals.n_pins].axis = axis;
+    fault_signals.motor[fault_signals.n_pins].secondary = secondary;
+    fault_signals.motor[fault_signals.n_pins++].pin = pin;
 }
 
-static void update_motor_fault_status (void)
+static void motor_fault_populate_pins (void)
+{
+    if(fault_signals.n_pins)
+        return;
+
+    motor_fault_register_pin(X_AXIS, false, X_MOTOR_FAULT_PIN);
+    motor_fault_register_pin(Y_AXIS, false, Y_MOTOR_FAULT_PIN);
+    motor_fault_register_pin(Z_AXIS, false, Z_MOTOR_FAULT_PIN);
+
+#ifdef M3_MOTOR_FAULT_PIN
+  #ifdef A_AXIS
+    motor_fault_register_pin(A_AXIS, false, M3_MOTOR_FAULT_PIN);
+  #elif X_GANGED
+    motor_fault_register_pin(X_AXIS, true, M3_MOTOR_FAULT_PIN);
+  #elif Y_GANGED
+    motor_fault_register_pin(Y_AXIS, true, M3_MOTOR_FAULT_PIN);
+  #elif Z_GANGED
+    motor_fault_register_pin(Z_AXIS, true, M3_MOTOR_FAULT_PIN);
+  #endif
+#endif
+#ifdef M4_MOTOR_FAULT_PIN
+  #ifdef B_AXIS
+    motor_fault_register_pin(B_AXIS, false, M4_MOTOR_FAULT_PIN);
+  #elif X_GANGED
+    motor_fault_register_pin(X_AXIS, true, M4_MOTOR_FAULT_PIN);
+  #elif Y_GANGED
+    motor_fault_register_pin(Y_AXIS, true, M4_MOTOR_FAULT_PIN);
+  #elif Z_GANGED
+    motor_fault_register_pin(Z_AXIS, true, M4_MOTOR_FAULT_PIN);
+  #endif
+#endif
+}
+
+static void onMotorFaultIRQ (void *data)
 {
     uint_fast8_t idx;
 
+    (void)data;
+
     stepper_status.fault.state = 0;
 
-    if(!motor_fault_armed)
+    if(!motor_fault_armed || !settings.motor_fault_enable.mask)
         return;
 
-    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
-        if(motor_fault_active(fault_pins[idx])) {
-            stepper_status.fault.state = 1;
-            break;
+    for(idx = 0; idx < fault_signals.n_pins; idx++) {
+        if(bit_istrue(settings.motor_fault_enable.mask, bit(fault_signals.motor[idx].axis))) {
+            bool inverted = bit_istrue(settings.motor_fault_invert.mask, bit(fault_signals.motor[idx].axis));
+
+            if((DIGITAL_IN(fault_signals.motor[idx].pin) != 0) ^ inverted)
+                xbar_stepper_state_set(&stepper_status.fault, fault_signals.motor[idx].axis, fault_signals.motor[idx].secondary);
         }
+    }
+
+    if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP))) {
+        control_signals_t signals = hal_control_get_state();
+        signals.motor_fault = On;
+        hal.control.interrupt_callback(signals);
     }
 }
 
@@ -103,11 +148,11 @@ static void motor_fault_irq_handler (void)
     uint_fast8_t idx;
     bool changed = false;
 
-    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
-        uint32_t events = gpio_get_irq_event_mask(fault_pins[idx]);
+    for(idx = 0; idx < fault_signals.n_pins; idx++) {
+        uint32_t events = gpio_get_irq_event_mask(fault_signals.motor[idx].pin);
 
         if(events) {
-            gpio_acknowledge_irq(fault_pins[idx], events);
+            gpio_acknowledge_irq(fault_signals.motor[idx].pin, events);
             changed = true;
         }
     }
@@ -115,11 +160,7 @@ static void motor_fault_irq_handler (void)
     if(!changed)
         return;
 
-    update_motor_fault_status();
-
-    if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP))) {
-        system_set_exec_alarm(Alarm_MotorFault);
-    }
+    onMotorFaultIRQ(NULL);
 }
 
 static void arm_motor_fault_monitor (void *data)
@@ -130,46 +171,78 @@ static void arm_motor_fault_monitor (void *data)
 
     motor_fault_armed = true;
 
-    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++)
-        gpio_set_irq_enabled(fault_pins[idx], GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);
+    for(idx = 0; idx < fault_signals.n_pins; idx++)
+        gpio_set_irq_enabled(fault_signals.motor[idx].pin, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true);
 
-    update_motor_fault_status();
-
-    if(stepper_status.fault.state && !(state_get() & (STATE_ALARM|STATE_ESTOP)))
-        system_set_exec_alarm(Alarm_MotorFault);
+    onMotorFaultIRQ(NULL);
 }
 
 static stepper_status_t getDriverStatus (bool reset)
 {
     if(reset)
         stepper_status.fault.state = 0;
-    else if(motor_fault_armed)
-        update_motor_fault_status();
 
     return stepper_status;
 }
 
-static void motor_fault_init (void *arg)
+static control_signals_t getControlState (void)
+{
+    control_signals_t state = hal_control_get_state();
+
+    state.motor_fault = stepper_status.fault.state != 0;
+
+    return state;
+}
+
+static void motor_fault_init (void)
 {
     uint_fast8_t idx;
 
-    hal.stepper.status = getDriverStatus;
-    motor_fault_armed = false;
+    motor_fault_populate_pins();
 
-    for(idx = 0; idx < sizeof(fault_pins) / sizeof(fault_pins[0]); idx++) {
-        gpio_init(fault_pins[idx]);
-        gpio_set_dir(fault_pins[idx], GPIO_IN);
-        gpio_set_irq_enabled(fault_pins[idx], GPIO_IRQ_ALL, false);
+    if(motor_fault_initialized)
+        return;
+
+    for(idx = 0; idx < fault_signals.n_pins; idx++) {
+        gpio_init(fault_signals.motor[idx].pin);
+        gpio_set_dir(fault_signals.motor[idx].pin, GPIO_IN);
+        gpio_set_irq_enabled(fault_signals.motor[idx].pin, GPIO_IRQ_ALL, false);
     }
 
-#if NUM_BANK0_GPIOS > 32
-    gpio_add_raw_irq_handler_masked64(fault_pin_mask, motor_fault_irq_handler);
-#else
-    gpio_add_raw_irq_handler_masked(fault_pin_mask, motor_fault_irq_handler);
-#endif
-    irq_set_enabled(IO_IRQ_BANK0, true);
+    motor_fault_initialized = true;
+}
 
-    task_add_delayed(arm_motor_fault_monitor, NULL, MOTOR_FAULT_ARM_DELAY_MS);
+static bool driverSetup (settings_t *settings)
+{
+    if(!driver_setup(settings))
+        return false;
+
+    motor_fault_init();
+
+    if((hal.signals_cap.motor_fault = !!settings->motor_fault_enable.value && fault_signals.n_pins)) {
+
+        if(!motor_fault_irq_installed) {
+#if NUM_BANK0_GPIOS > 32
+            gpio_add_raw_irq_handler_masked64(fault_pin_mask, motor_fault_irq_handler);
+#else
+            gpio_add_raw_irq_handler_masked(fault_pin_mask, motor_fault_irq_handler);
+#endif
+            irq_set_enabled(IO_IRQ_BANK0, true);
+            motor_fault_irq_installed = true;
+        }
+
+        stepper_status.fault.state = 0;
+        motor_fault_armed = false;
+
+        hal.stepper.status = getDriverStatus;
+
+        hal_control_get_state = hal.control.get_state;
+        hal.control.get_state = getControlState;
+
+        task_add_delayed(arm_motor_fault_monitor, NULL, MOTOR_FAULT_ARM_DELAY_MS);
+    }
+
+    return true;
 }
 
 // Shift register Output Enable — pulled LOW at boot to enable 74HCT595 outputs.
@@ -228,8 +301,10 @@ void board_init (void)
     saved_on_homing_completed = grbl.on_homing_completed;
     grbl.on_homing_completed = onHomingCompleted;
 
+    driver_setup = hal.driver_setup;
+    hal.driver_setup = driverSetup;
+
     task_run_on_startup(sr_oe_init, NULL);
-    task_run_on_startup(motor_fault_init, NULL);
     task_run_on_startup(home_indicator_init, NULL);
 }
 

--- a/boards/slblite_map.h
+++ b/boards/slblite_map.h
@@ -161,15 +161,19 @@
   #define TOOLSETTER_PIN          AUXINPUT0_PIN
 #endif
 
-// CLS Motor Fault/Alarm Inputs monitored directly by slblite.c.
-#define SLBLITE_X_MOTOR_FAULT_PIN   7
-#define SLBLITE_Y_MOTOR_FAULT_PIN   8
-#define SLBLITE_Z_MOTOR_FAULT_PIN   9
-#ifdef M3_AVAILABLE
-  #define SLBLITE_M3_MOTOR_FAULT_PIN  10
-#endif
-#ifdef M4_AVAILABLE
-  #define SLBLITE_M4_MOTOR_FAULT_PIN  11
+// CLS Motor Fault/Alarm Inputs monitored by slblite.c, but advertised through the standard motor-fault pin macros.
+#if MOTOR_FAULT_ENABLE
+  #define X_MOTOR_FAULT_PIN       7
+  #define Y_MOTOR_FAULT_PIN       8
+  #define Z_MOTOR_FAULT_PIN       9
+  // Satisfy the generic single-pin motor-fault sanity check.
+  #define MOTOR_FAULT_PIN         X_MOTOR_FAULT_PIN
+  #ifdef M3_AVAILABLE
+    #define M3_MOTOR_FAULT_PIN      10
+  #endif
+  #ifdef M4_AVAILABLE
+    #define M4_MOTOR_FAULT_PIN      11
+  #endif
 #endif
 
 // SPI: SD and Ethernet

--- a/boards/slblite_map.h
+++ b/boards/slblite_map.h
@@ -54,15 +54,10 @@
 #define HOME_INDICATOR_XYZA_PIN AUXOUTPUT0_PIN
 #define HOME_INDICATOR_Z_PIN    AUXOUTPUT1_PIN
 
-#define AUXINPUT0_PIN           11 // Motor fault M4
-#define AUXINPUT1_PIN           10 // Motor fault M3
-#define AUXINPUT2_PIN            7 // Motor fault X
-#define AUXINPUT3_PIN            8 // Motor fault Y
-#define AUXINPUT4_PIN            9 // Motor fault Z
-#define AUXINPUT5_PIN           23 // Toolsetter
-#define AUXINPUT6_PIN           22 // Probe
-#define AUXINPUT7_PIN           39 // Reset/EStop
-#define AUXINPUT8_PIN           27 // Spindle Detect
+#define AUXINPUT0_PIN           23 // Toolsetter
+#define AUXINPUT1_PIN           22 // Probe
+#define AUXINPUT2_PIN           39 // Reset/EStop
+#define AUXINPUT3_PIN           27 // Spindle Detect
 
 #define USE_EXPANDERS // Uses 74HCT595 Expansion on PIO
 #define OUT_SHIFT_REGISTER       8 // How many bits are used in the shift register, 8 for 74HCT595
@@ -155,26 +150,26 @@
 #if CONTROL_ENABLE
   #undef CONTROL_ENABLE
   #define CONTROL_ENABLE CONTROL_HALT // EStop is treated as a hard control input that halts the machine and requires a reset to clear
-  #define RESET_PIN               AUXINPUT7_PIN
+  #define RESET_PIN               AUXINPUT2_PIN
 #endif
 
 // Probe and Tool Length Sensors
 #if PROBE_ENABLE
-  #define PROBE_PIN               AUXINPUT6_PIN
+  #define PROBE_PIN               AUXINPUT1_PIN
 #endif
 #if TOOLSETTER_ENABLE
-  #define TOOLSETTER_PIN          AUXINPUT5_PIN
+  #define TOOLSETTER_PIN          AUXINPUT0_PIN
 #endif
 
 // CLS Motor Fault/Alarm Inputs monitored directly by slblite.c.
-#define SLBLITE_X_MOTOR_FAULT_PIN   AUXINPUT2_PIN
-#define SLBLITE_Y_MOTOR_FAULT_PIN   AUXINPUT3_PIN
-#define SLBLITE_Z_MOTOR_FAULT_PIN   AUXINPUT4_PIN
+#define SLBLITE_X_MOTOR_FAULT_PIN   7
+#define SLBLITE_Y_MOTOR_FAULT_PIN   8
+#define SLBLITE_Z_MOTOR_FAULT_PIN   9
 #ifdef M3_AVAILABLE
-  #define SLBLITE_M3_MOTOR_FAULT_PIN  AUXINPUT1_PIN
+  #define SLBLITE_M3_MOTOR_FAULT_PIN  10
 #endif
 #ifdef M4_AVAILABLE
-  #define SLBLITE_M4_MOTOR_FAULT_PIN  AUXINPUT0_PIN
+  #define SLBLITE_M4_MOTOR_FAULT_PIN  11
 #endif
 
 // SPI: SD and Ethernet

--- a/boards/slblite_map.h
+++ b/boards/slblite_map.h
@@ -166,20 +166,15 @@
   #define TOOLSETTER_PIN          AUXINPUT5_PIN
 #endif
 
-// CLS Motor Fault/Alarm Inputs
-#if MOTOR_FAULT_ENABLE
-  #define X_MOTOR_FAULT_PIN       AUXINPUT2_PIN
-  #define Y_MOTOR_FAULT_PIN       AUXINPUT3_PIN
-  #define Z_MOTOR_FAULT_PIN       AUXINPUT4_PIN
-  // Satisfy the generic single-pin motor-fault sanity check.
-  // SLB Lite overrides control-state handling in board_init() to aggregate per-axis faults.
-  #define MOTOR_FAULT_PIN         X_MOTOR_FAULT_PIN
-  #ifdef M3_AVAILABLE
-    #define M3_MOTOR_FAULT_PIN      AUXINPUT1_PIN
-  #endif
-  #ifdef M4_AVAILABLE
-    #define M4_MOTOR_FAULT_PIN      AUXINPUT0_PIN
-  #endif
+// CLS Motor Fault/Alarm Inputs monitored directly by slblite.c.
+#define SLBLITE_X_MOTOR_FAULT_PIN   AUXINPUT2_PIN
+#define SLBLITE_Y_MOTOR_FAULT_PIN   AUXINPUT3_PIN
+#define SLBLITE_Z_MOTOR_FAULT_PIN   AUXINPUT4_PIN
+#ifdef M3_AVAILABLE
+  #define SLBLITE_M3_MOTOR_FAULT_PIN  AUXINPUT1_PIN
+#endif
+#ifdef M4_AVAILABLE
+  #define SLBLITE_M4_MOTOR_FAULT_PIN  AUXINPUT0_PIN
 #endif
 
 // SPI: SD and Ethernet


### PR DESCRIPTION
Updated board driver per your suggestions 

1) Switched to hal.control.interuppt_callback 
https://github.com/Sienci-Labs/RP2040/blob/45c85eb6af9d7eaade3e14e4a7fcdd058f2a53e8/boards/slblite.c#L142

2) Realtime Report now includes Pn:F when the fault occurs https://github.com/Sienci-Labs/RP2040/blob/45c85eb6af9d7eaade3e14e4a7fcdd058f2a53e8/boards/slblite.c#L188

3) I also brough back  $744/745 (not done a lot of testing on it yet, but seems to work) I used the same model SLB relies on: advertise standard motor-fault pins, let the core expose the settings, then board code implements the runtime behavior. 