### PR TITLE
bolangsk board pin map additions

### DIFF
--- a/boards/bolangsk_map.h
+++ b/boards/bolangsk_map.h
@@ -66,14 +66,12 @@
 #define M3_AVAILABLE
 #define M3_DIRECTION_PIN        15 //A|D pin 
 #define M3_LIMIT_PIN            26 //LIMIT A pin
-#define M3_ENABLE_PIN           25
 #endif
 
 #if N_ABC_MOTORS == 2
 #define M4_AVAILABLE
 #define M4_DIRECTION_PIN        16 //B|D pin
 #define M4_LIMIT_PIN            30 //LIMIT B pin
-#define M4_ENABLE_PIN           26
 #endif
 
 #define AUXOUTPUT0_PORT         GPIO_OUTPUT  //out0

--- a/driver.c
+++ b/driver.c
@@ -587,6 +587,9 @@ static output_signal_t outputpin[] = {
 #ifdef AUXOUTPUT7_PORT
     { .id = Output_Aux7,         .port = AUXOUTPUT7_PORT,  .pin = AUXOUTPUT7_PIN,        .group = PinGroup_AuxOutput},
 #endif
+#ifdef AUXOUTPUT8_PORT
+    { .id = Output_Aux8,         .port = AUXOUTPUT8_PORT,  .pin = AUXOUTPUT8_PIN,        .group = PinGroup_AuxOutput},
+#endif
 #ifdef AUXOUTPUT0_PWM_PIN
     { .id = Output_Analog_Aux0, .port = GPIO_OUTPUT, .pin = AUXOUTPUT0_PWM_PIN, .group = PinGroup_AuxOutputAnalog, .mode = { PINMODE_PWM } },
 #endif


### PR DESCRIPTION
Bolangsk board has mist on auxoutput pin 8 by default which was missing in driver.c, and mist was missing from $pins.
Removed A,B axis enable pins from board map.
Maybe adding something like this commented out makes sense?

```
// Define stepper driver enable/disable output pin.
#define ENABLE_PORT             GPIO_OUTPUT  
#define STEPPERS_ENABLE_PIN     AUXOUTPUT0_PIN //Use any of the free auxN pins as stepper enable signal
```
